### PR TITLE
Removed TravisCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
     <a href="https://masterer.apple.com/swift"><img src="https://img.shields.io/badge/language-swift%204%20%7C%20objective--c-brigthgreen.svg" alt="Supported languages" /></a>
     <a href="https://cocoapods.org/pods/Backtrace"><img src="https://img.shields.io/cocoapods/v/Backtrace.svg?style=flat" alt="CocoaPods compatible" /></a>
     <img src="http://img.shields.io/badge/license-MIT-lightgrey.svg?style=flat" alt="License: MIT" />
-    <img src="https://travis-ci.org/backtrace-labs/backtrace-cocoa.svg?branch=master"/>
 </p>
 
 ## Minimal usage


### PR DESCRIPTION
Removed TravisCI badge that we're not using anymore (we migrated to github actions)