### PR TITLE
Clean up file attachments API

### DIFF
--- a/Examples/Example-iOS/AppDelegate.swift
+++ b/Examples/Example-iOS/AppDelegate.swift
@@ -36,9 +36,12 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         BacktraceClient.shared?.attributes = ["foo": "bar", "testing": true]
         
         let fileName = "sample.txt"
-        let fileUrl = try? createAndWriteFile(fileName)
+        guard let fileUrl = try? createAndWriteFile(fileName) else {
+            print("Could not create the file attachment")
+            return false
+        }
         var crashAttachments = Attachments()
-        crashAttachments[fileName] = fileUrl
+        crashAttachments.append(fileUrl)
         BacktraceClient.shared?.attachments = crashAttachments
 
         BacktraceClient.shared?.loggingDestinations = [BacktraceBaseDestination(level: .debug)]

--- a/Sources/Features/Attributes/AttributesProvider.swift
+++ b/Sources/Features/Attributes/AttributesProvider.swift
@@ -14,7 +14,7 @@ final class AttributesProvider {
     
     // attributes can be modified on runtime
     var attributes: Attributes = [:]
-    var attachments: Attachments = [:]
+    var attachments: Attachments = []
     private let attributesSources: [AttributesSource]
     private let faultInfo: FaultInfo
     
@@ -45,7 +45,7 @@ extension AttributesProvider: SignalContext {
     }
     
     var attachmentPaths: [String] {
-        return attachments.map(\.value.path)
+        return attachments.map(\.path)
     }
     
     var allAttributes: Attributes {

--- a/Sources/Features/Client/Model/AttachmentBookmarkHandler.swift
+++ b/Sources/Features/Client/Model/AttachmentBookmarkHandler.swift
@@ -10,9 +10,8 @@ enum AttachmentBookmarkHandlerImpl: AttachmentBookmarkHandler {
         var attachmentsBookmarksDict = Bookmarks()
         for attachment in attachments {
             do {
-                let bookmark = try attachment.bookmarkData(options: URL.BookmarkCreationOptions.minimalBookmark)
-                let fileName = attachment.lastPathComponent
-                attachmentsBookmarksDict[fileName] = bookmark
+                let bookmark = try attachment.bookmarkData(options: .minimalBookmark)
+                attachmentsBookmarksDict[attachment.path] = bookmark
             } catch {
                 BacktraceLogger.error("Could not bookmark attachment file URL. Error: \(error)")
                 continue

--- a/Sources/Features/Client/Model/AttachmentBookmarkHandler.swift
+++ b/Sources/Features/Client/Model/AttachmentBookmarkHandler.swift
@@ -10,8 +10,9 @@ enum AttachmentBookmarkHandlerImpl: AttachmentBookmarkHandler {
         var attachmentsBookmarksDict = Bookmarks()
         for attachment in attachments {
             do {
-                let bookmark = try attachment.value.bookmarkData(options: URL.BookmarkCreationOptions.minimalBookmark)
-                attachmentsBookmarksDict[attachment.key] = bookmark
+                let bookmark = try attachment.bookmarkData(options: URL.BookmarkCreationOptions.minimalBookmark)
+                let fileName = attachment.lastPathComponent
+                attachmentsBookmarksDict[fileName] = bookmark
             } catch {
                 BacktraceLogger.error("Could not bookmark attachment file URL. Error: \(error)")
                 continue
@@ -35,7 +36,7 @@ enum AttachmentBookmarkHandlerImpl: AttachmentBookmarkHandler {
                 BacktraceLogger.error("Bookmark data is stale. This should not happen")
                 continue
             }
-            attachments[bookmark.key] = fileUrl
+            attachments.append(fileUrl)
         }
         return attachments
     }

--- a/Sources/Public/BacktraceClientCustomizing.swift
+++ b/Sources/Public/BacktraceClientCustomizing.swift
@@ -7,8 +7,7 @@ public typealias BacktraceClientProtocol = BacktraceReporting & BacktraceClientC
 public typealias Attributes = [String: Any]
 
 /// Type-alias of passing file attachments to library.
-/// Expected format: Filename, File URL bookmark
-public typealias Attachments = [String: URL]
+public typealias Attachments = [URL]
 
 /// Type-alias of storing file attachments on disk (as a bookmark)
 /// Expected format: Filename, File URL bookmark

--- a/Sources/Public/BacktraceCrashReporter.swift
+++ b/Sources/Public/BacktraceCrashReporter.swift
@@ -72,20 +72,21 @@ extension BacktraceCrashReporter: CrashReporting {
             BacktraceLogger.error("Could not get cache directory URL")
             return [URL]()
         }
-        let attachments = (try? AttachmentsStorage.retrieve(fileName: BacktraceCrashReporter.crashName)) ?? [:]
+        let attachments = (try? AttachmentsStorage.retrieve(fileName: BacktraceCrashReporter.crashName)) ?? []
         var copiedFileAttachments = [URL]()
         for attachment in attachments {
             let fileManager = FileManager.default
-            let copiedAttachmentPath = directoryUrl.appendingPathComponent(attachment.key)
+            let fileName = attachment.lastPathComponent
+            let copiedAttachmentPath = directoryUrl.appendingPathComponent(fileName)
             do {
-                if !fileManager.fileExists(atPath: attachment.value.path) {
+                if !fileManager.fileExists(atPath: attachment.path) {
                     BacktraceLogger.error("File attachment from previous session does not exist")
                     continue
                 }
                 if fileManager.fileExists(atPath: copiedAttachmentPath.path) {
                     try fileManager.removeItem(atPath: copiedAttachmentPath.path)
                 }
-                try fileManager.copyItem(at: attachment.value, to: copiedAttachmentPath)
+                try fileManager.copyItem(at: attachment, to: copiedAttachmentPath)
                 copiedFileAttachments.append(copiedAttachmentPath)
             } catch {
                 BacktraceLogger.error("Could not copy bookmarked attachment file from previous session. Error: \(error)")

--- a/Tests/AttachmentStorageTests.swift
+++ b/Tests/AttachmentStorageTests.swift
@@ -16,7 +16,7 @@ final class AttachmentStorageTests: QuickSpec {
                 guard let fileUrl = try? self.createAFile() else {
                     throw FileError.fileNotWritten
                 }
-                crashAttachments["myFile"] = fileUrl
+                crashAttachments.append(fileUrl)
                 
                 let attachmentsFileName = "attachments"
                 try? AttachmentsStorage.store(crashAttachments,
@@ -28,7 +28,7 @@ final class AttachmentStorageTests: QuickSpec {
                     (try? AttachmentsStorage.retrieve(fileName: attachmentsFileName,
                                                       storage: storage,
                                                       bookmarkHandler: bookmarkHandler)) ?? Attachments()
-                let attachmentPaths = attachments.map(\.value.path)
+                let attachmentPaths = attachments.map(\.path)
                 
                 expect(attachmentPaths).toNot(beNil())
                 expect(attachmentPaths.count).to(be(1))
@@ -49,7 +49,7 @@ final class AttachmentStorageTests: QuickSpec {
                     (try? AttachmentsStorage.retrieve(fileName: attachmentsFileName,
                                                       storage: storage,
                                                       bookmarkHandler: bookmarkHandler)) ?? Attachments()
-                let attachmentPaths = attachments.map(\.value.path)
+                let attachmentPaths = attachments.map(\.path)
                 
                 expect(attachmentPaths).toNot(beNil())
                 expect(attachmentPaths.count).to(be(0))

--- a/Tests/Mocks/AttachmentBookmarkHandlerMock.swift
+++ b/Tests/Mocks/AttachmentBookmarkHandlerMock.swift
@@ -2,11 +2,15 @@ import Foundation
 import XCTest
 @testable import Backtrace
 
+enum AttachmentsBookmarkError: Error {
+    case invalidUrl
+}
+
 enum AttachmentBookmarkHandlerMock: AttachmentBookmarkHandler {
     static func convertAttachmentUrlsToBookmarks(_ attachments: Attachments) throws -> Bookmarks {
         var attachmentsBookmarksDict = Bookmarks()
         for attachment in attachments {
-            attachmentsBookmarksDict[attachment.key] = attachment.value.path.data(using: .utf8)
+            attachmentsBookmarksDict[attachment.lastPathComponent] = attachment.path.data(using: .utf8)
         }
         return attachmentsBookmarksDict
     }
@@ -14,7 +18,10 @@ enum AttachmentBookmarkHandlerMock: AttachmentBookmarkHandler {
     static func extractAttachmentUrls(_ bookmarks: Bookmarks) throws -> Attachments {
         var attachments = Attachments()
         for bookmark in bookmarks {
-            attachments[bookmark.key] = URL(string: String(data: bookmark.value, encoding: .utf8) ?? String())
+            guard let fileUrl = URL(string: String(data: bookmark.value, encoding: .utf8) ?? String()) else {
+                throw AttachmentsBookmarkError.invalidUrl
+            }
+            attachments.append(fileUrl)
         }
         return attachments
     }

--- a/Tests/Mocks/AttachmentBookmarkHandlerMock.swift
+++ b/Tests/Mocks/AttachmentBookmarkHandlerMock.swift
@@ -10,7 +10,7 @@ enum AttachmentBookmarkHandlerMock: AttachmentBookmarkHandler {
     static func convertAttachmentUrlsToBookmarks(_ attachments: Attachments) throws -> Bookmarks {
         var attachmentsBookmarksDict = Bookmarks()
         for attachment in attachments {
-            attachmentsBookmarksDict[attachment.lastPathComponent] = attachment.path.data(using: .utf8)
+            attachmentsBookmarksDict[attachment.path] = attachment.path.data(using: .utf8)
         }
         return attachmentsBookmarksDict
     }


### PR DESCRIPTION
Let the user specify their file attachments as simply a list of URLs. Previously we required the user to specify their file attachments as a dictionary of String/URL where the strings are the filename. But we can extract the filename directly from the URL to provide a simpler API for the user.