### PR TITLE
Disabled OOM reports

### DIFF
--- a/Sources/Features/Client/BacktraceReporter.swift
+++ b/Sources/Features/Client/BacktraceReporter.swift
@@ -32,7 +32,7 @@ final class BacktraceReporter {
         let attributesProvider = AttributesProvider(reportHostName: dbSettings.reportHostName)
         self.attributesProvider = attributesProvider
         if #available(iOS 15.3.1, *) {
-            BacktraceLogger.debug("The OOM support is disadbled for this version of iOS. Skipping OOM check.")
+            BacktraceLogger.debug("The OOM support is disabled for this version of iOS. Skipping OOM check.")
             oomSupport = false
         }
         if(oomSupport == true){

--- a/Sources/Features/Client/BacktraceReporter.swift
+++ b/Sources/Features/Client/BacktraceReporter.swift
@@ -8,7 +8,6 @@ final class BacktraceReporter {
     private(set) var attributesProvider: SignalContext
     private(set) var backtraceOomWatcher: BacktraceOomWatcher!
     let repository: PersistentRepository<BacktraceReport>
-    var oomSupport : Bool = true
 
     #if os(macOS)
     lazy var memoryPressureSource: DispatchSourceMemoryPressure = {
@@ -33,9 +32,7 @@ final class BacktraceReporter {
         self.attributesProvider = attributesProvider
         if #available(iOS 15.3.1, *) {
             BacktraceLogger.debug("The OOM support is disabled for this version of iOS. Skipping OOM check.")
-            oomSupport = false
-        }
-        if(oomSupport == true){
+        }else{
             self.backtraceOomWatcher = BacktraceOomWatcher(
                 repository: self.repository,
                 crashReporter: self.reporter,

--- a/Sources/Public/BacktraceClient.swift
+++ b/Sources/Public/BacktraceClient.swift
@@ -171,7 +171,9 @@ extension BacktraceClient: BacktraceReporting {
         }
 
         if self.configuration.detectOom {
-            self.reporter.enableOomWatcher()
+            if self.reporter.oomSupport {
+                self.reporter.enableOomWatcher()
+            }
         }
 
         try reporter.enableCrashReporter()

--- a/Sources/Public/BacktraceClient.swift
+++ b/Sources/Public/BacktraceClient.swift
@@ -171,7 +171,9 @@ extension BacktraceClient: BacktraceReporting {
         }
 
         if self.configuration.detectOom {
-            if self.reporter.oomSupport {
+            if #available(iOS 15.3.1, *) {
+                BacktraceLogger.debug("Not enabling OomWatcher for iOS 15.3.1+")
+            }else{
                 self.reporter.enableOomWatcher()
             }
         }


### PR DESCRIPTION
Disabled OOM reports for 15.3.1+ for backtrace-cocoa (so invalid OOM reports don't crash it)