### PR TITLE
Immutable error message

### DIFF
--- a/Sources/Features/Attributes/DefaultAttributes.swift
+++ b/Sources/Features/Attributes/DefaultAttributes.swift
@@ -4,7 +4,7 @@ import CoreLocation
 
 final class FaultInfo: AttributesSource {
     var faultMessage: String?
-    var immutable: [String: Any?] {
+    var mutable: [String: Any?] {
         return ["error.message": faultMessage]
     }
 }

--- a/Tests/AttributesTests.swift
+++ b/Tests/AttributesTests.swift
@@ -58,6 +58,17 @@ final class AttributesTests: QuickSpec {
             }
         }
 
+        describe("Fault information") {
+            it("can override fault information") {
+                let oldAttributeValue = "a"
+                let newAttributeValue = "b"
+                let attributes = AttributesProvider()
+                attributes.set(faultMessage: oldAttributeValue)
+                attributes.set(faultMessage: newAttributeValue)
+                expect{ attributes.allAttributes["error.message"] as? String}.to(equal(newAttributeValue))
+            }
+        }
+
         describe("Metrics Info") {
             it("will NOT set application.version and application.session if metrics attributes are NOT enabled") {
                 let attributes = MetricsInfo()


### PR DESCRIPTION
# Why

This diff changes a way how we read attributes during the report creation process. By changing mutable into immutable we can read error message every time when we create report attributes 