### PR TITLE
Added by default application.session and application.version attributes

### DIFF
--- a/Sources/Features/Attributes/DefaultAttributes.swift
+++ b/Sources/Features/Attributes/DefaultAttributes.swift
@@ -254,10 +254,8 @@ struct MetricsInfo: AttributesSource {
     }
 
     var immutable: [String: Any?] {
-        return MetricsInfo.isMetricsEnabled ?
-            ["application.version": Backtrace.applicationVersion,
-             "application.session": MetricsInfo.session] :
-            [:]
+        return ["application.version": Backtrace.applicationVersion,
+             "application.session": MetricsInfo.session];
     }
 }
 

--- a/Tests/AttributesTests.swift
+++ b/Tests/AttributesTests.swift
@@ -70,13 +70,13 @@ final class AttributesTests: QuickSpec {
         }
 
         describe("Metrics Info") {
-            it("will NOT set application.version and application.session if metrics attributes are NOT enabled") {
+            it("will always set application.version and application.session even if metrics system is disabled") {
                 let attributes = MetricsInfo()
-                expect { attributes.immutable["application.version"]}.to(beNil())
-                expect { attributes.immutable["application.session"]}.to(beNil())
+                expect { attributes.immutable["application.version"]}.notTo(beNil())
+                expect { attributes.immutable["application.session"]}.notTo(beNil())
             }
 
-            it("will set application.version and application.session if metrics attributes are enabled") {
+            it("will always set application.version and application.session ") {
                 let attributes = MetricsInfo()
                 MetricsInfo.enableMetrics()
                 expect { attributes.immutable["application.version"]}.toNot(beNil())
@@ -105,17 +105,17 @@ final class AttributesTests: QuickSpec {
         }
 
         describe("Attributes Provider") {
-            it("will NOT set application.version and application.session if metrics attributes are NOT enabled") {
+            it("will set application.version and application.session even if metrics attributes are NOT enabled") {
                 let attributes = AttributesProvider()
-                expect { attributes.allAttributes["application.version"]}.to(beNil())
-                expect { attributes.allAttributes["application.session"]}.to(beNil())
+                expect { attributes.allAttributes["application.version"]}.notTo(beNil())
+                expect { attributes.allAttributes["application.session"]}.notTo(beNil())
             }
 
-            it("will set application.version and application.session if metrics attributes are enabled") {
+            it("will always set application.version and application.session ") {
                 MetricsInfo.enableMetrics()
                 let attributes = AttributesProvider()
-                expect { attributes.allAttributes["application.version"]}.toNot(beNil())
-                expect { attributes.allAttributes["application.session"]}.toNot(beNil())
+                expect { attributes.allAttributes["application.version"]}.notTo(beNil())
+                expect { attributes.allAttributes["application.session"]}.notTo(beNil())
                 MetricsInfo.disableMetrics()
             }
         }

--- a/Tests/BacktraceReporterTests.swift
+++ b/Tests/BacktraceReporterTests.swift
@@ -179,23 +179,23 @@ final class BacktraceReporterTests: QuickSpec {
                     expect { result2.report?.attributes["a"] }.to(beNil())
                 }
 
-                it("report should NOT have metrics attributes if metrics is NOT enabled") {
+                it("report should have application version and session attributes") {
                     let delegate = BacktraceClientDelegateMock()
                     let backtraceReport = try reporter.generate()
                     urlSession.response = MockOkResponse()
                     backtraceApi.delegate = delegate
 
                     delegate.willSendClosure = { report in
-                        expect { report.attributes["application.session"] }.to(beNil())
-                        expect { report.attributes["application.version"] }.to(beNil())
+                        expect { report.attributes["application.session"] }.notTo(beNil())
+                        expect { report.attributes["application.version"] }.notTo(beNil())
                         return report
                     }
 
                     let result = reporter.send(resource: backtraceReport)
 
                     expect { result.backtraceStatus }.to(equal(.ok))
-                    expect { result.report?.attributes["application.session"] }.to(beNil())
-                    expect { result.report?.attributes["application.version"] }.to(beNil())
+                    expect { result.report?.attributes["application.session"] }.notTo(beNil())
+                    expect { result.report?.attributes["application.version"] }.notTo(beNil())
                 }
 
                 it("report should have metrics attributes if metrics is enabled") {


### PR DESCRIPTION
# Why

This diff always adds application.session and application.version attributes by default. Previously metrics system was required to make them available


ref: BT-745