### PR TITLE
Treat build version as an application.version

### DIFF
--- a/Sources/Features/Attributes/DefaultAttributes.swift
+++ b/Sources/Features/Attributes/DefaultAttributes.swift
@@ -255,6 +255,7 @@ struct MetricsInfo: AttributesSource {
 
     var immutable: [String: Any?] {
         return ["application.version": Backtrace.applicationVersion,
+             "application.build": Backtrace.buildVersion,
              "application.session": MetricsInfo.session];
     }
 }

--- a/Sources/Features/Extensions/Foundation+Extensions.swift
+++ b/Sources/Features/Extensions/Foundation+Extensions.swift
@@ -27,4 +27,8 @@ extension Bundle {
     var releaseVersionNumber: String? {
         return infoDictionary?["CFBundleShortVersionString"] as? String
     }
+    
+    var buildVersionNumber: String? {
+        return infoDictionary?["CFBundleVersion"] as? String
+    }
 }

--- a/Sources/Public/BacktraceClientCustomizing.swift
+++ b/Sources/Public/BacktraceClientCustomizing.swift
@@ -96,7 +96,7 @@ public typealias Bookmarks = [String: Data]
 
 public let applicationName = Bundle.main.displayName
 
-public let applicationVersion = Bundle.main.releaseVersionNumber
+public let applicationVersion = Bundle.main.buildVersionNumber
 
 public let defaultMetricsBaseUrlString = "https://events.backtrace.io/api/"
 

--- a/Sources/Public/BacktraceClientCustomizing.swift
+++ b/Sources/Public/BacktraceClientCustomizing.swift
@@ -96,7 +96,9 @@ public typealias Bookmarks = [String: Data]
 
 public let applicationName = Bundle.main.displayName
 
-public let applicationVersion = Bundle.main.buildVersionNumber
+public let applicationVersion = Bundle.main.releaseVersionNumber
+
+public let buildVersion = Bundle.main.buildVersionNumber
 
 public let defaultMetricsBaseUrlString = "https://events.backtrace.io/api/"
 


### PR DESCRIPTION
# Why

This diff changes how we read the application.version attribute

BT-745