### PR TITLE
Release 2.0.1

### DIFF
--- a/Backtrace.podspec
+++ b/Backtrace.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Backtrace"
-  s.version      = "2.0.0"
+  s.version      = "2.0.1"
   s.swift_version = '5'
   s.summary      = "Backtrace's integration with iOS, macOS and tvOS"
   s.description  = "Reliable crash and hang reporting for iOS, macOS and tvOS."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Backtrace Cocoa Release Notes
 
+## Version 2.0.1
+- Added application.session and application.version attribute as defaults - no matter if the metrics integration is enabled or not.
+- Added application.build attribute that represents an app build version.
+
 ## Version 2.0.0
 - Adds Swift Package Manager support
 - Improves Breadcrumbs Swift implementation


### PR DESCRIPTION
This diff updates the backtrace-cocoa library version. 