### PR TITLE
Backtrace agent support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 2.0.1
 - Added application.session and application.version attribute as defaults - no matter if the metrics integration is enabled or not.
 - Added application.build attribute that represents an app build version.
+- Added backtrace.agent attribute that represents current agent name.
 
 ## Version 2.0.0
 - Adds Swift Package Manager support

--- a/Sources/Features/Attributes/DefaultAttributes.swift
+++ b/Sources/Features/Attributes/DefaultAttributes.swift
@@ -226,7 +226,8 @@ struct LibInfo: AttributesSource {
         return ["guid": LibInfo.guid(store: UserDefaultsStore.self).uuidString,
                 "lang.name": LibInfo.applicationLangName,
                 "lang.version": backtraceVersion,
-                "backtrace.version": backtraceVersion]
+                "backtrace.version": backtraceVersion,
+                "backtrace.agent": "backtrace-cocoa"]
     }
 
     static private func guid(store: UserDefaultsStore.Type) -> UUID {

--- a/Sources/Features/Attributes/DefaultAttributes.swift
+++ b/Sources/Features/Attributes/DefaultAttributes.swift
@@ -207,21 +207,8 @@ struct LibInfo: AttributesSource {
     private static let applicationGuidKey = "backtrace.unique.user.identifier"
     private static let applicationLangName = "backtrace-cocoa"
 
-    var backtraceVersion: String? {
-        
-#if SWIFT_PACKAGE
-        if let build = Bundle.main.infoDictionary?["CFBundleShortVersionString"] {
-            return build as? String
-        }
-#else
-        if let bundle = Bundle(identifier: "Backtrace.io.Backtrace"),
-           let build = bundle.infoDictionary?["CFBundleShortVersionString"] {
-            return build as? String
-        }
-#endif
-        return nil
-    }
-
+    var backtraceVersion = "2.0.1"
+    
     var immutable: [String: Any?] {
         return ["guid": LibInfo.guid(store: UserDefaultsStore.self).uuidString,
                 "lang.name": LibInfo.applicationLangName,


### PR DESCRIPTION
This diff adds backtrace.agent attribute to all backtrace-cocoa reports 