### PR TITLE
Add extension to the uploaded attachment

### DIFF
--- a/Sources/Features/Network/MultipartRequest.swift
+++ b/Sources/Features/Network/MultipartRequest.swift
@@ -65,9 +65,9 @@ extension MultipartRequest {
         body.appendString("\r\n")
 
         // attachments
-        for attachment in report.attachmentPaths.compactMap(Attachment.init(filePath:)) {
+        for attachment in Set(report.attachmentPaths).compactMap(Attachment.init(filePath:)) {
             body.appendString(boundaryPrefix)
-            body.appendString("Content-Disposition: form-data; name=\"\(attachment.name)\"; filename=\"\(attachment.name)\"\r\n")
+            body.appendString("Content-Disposition: form-data; name=\"\(attachment.filename)\"; filename=\"\(attachment.filename)\"\r\n")
             body.appendString("Content-Type: \(attachment.mimeType)\r\n\r\n")
             body.append(attachment.data)
             body.appendString("\r\n")

--- a/Sources/Features/Repository/Model/Attachment.swift
+++ b/Sources/Features/Repository/Model/Attachment.swift
@@ -7,7 +7,9 @@ import CoreServices
 
 struct Attachment {
     let data: Data
-    let name: String
+    // file name with extension that represents real file name
+    let filename: String
+    
     let mimeType: String
 
     // Make sure attachments are not bigger than 10 MB.
@@ -32,7 +34,7 @@ struct Attachment {
         }
 
         mimeType = Attachment.mimeTypeForPath(fileUrl: fileURL)
-        name = "attachment_" + (fileURL.lastPathComponent as NSString).deletingPathExtension + "_\(arc4random())"
+        filename = "attachment_" + fileURL.lastPathComponent
     }
 
     static private func mimeTypeForPath(fileUrl: URL) -> String {

--- a/Tests/AttachmentTests.swift
+++ b/Tests/AttachmentTests.swift
@@ -33,7 +33,7 @@ final class AttachmentTests: QuickSpec {
                     it("has mime type: text/plain") {
                         expect(attachment.mimeType).to(equal("text/plain"))
                         expect(attachment.data).toNot(beNil())
-                        expect(attachment.name).to(contain(["attachment_test_"]))
+                        expect(attachment.filename).to(contain(["attachment_test"]))
                     }
                 } else {
                     fail()


### PR DESCRIPTION
# Why

This diff adds the extension to file attachments. Thanks to this, our users can correctly see files in the web debugger view and don't need to rename them every time they download attachments 