### PR TITLE
Rename attributes and add them as default

### DIFF
--- a/Sources/Features/Attributes/AttributesProvider.swift
+++ b/Sources/Features/Attributes/AttributesProvider.swift
@@ -34,7 +34,7 @@ final class AttributesProvider {
                              LibInfo(),
                              LocationInfo(),
                              faultInfo,
-                             MetricsInfo(),
+                             ApplicationInfo(),
                              BreadcrumbsInfo()]
     }
 }

--- a/Sources/Features/Attributes/DefaultAttributes.swift
+++ b/Sources/Features/Attributes/DefaultAttributes.swift
@@ -232,23 +232,13 @@ struct LibInfo: AttributesSource {
     }
 }
 
-struct MetricsInfo: AttributesSource {
+struct ApplicationInfo: AttributesSource {
     private static let session = UUID().uuidString
-
-    static private var isMetricsEnabled = false
-
-    static func enableMetrics() {
-        isMetricsEnabled = true
-    }
-
-    static func disableMetrics() {
-        isMetricsEnabled = false
-    }
 
     var immutable: [String: Any?] {
         return ["application.version": Backtrace.applicationVersion,
              "application.build": Backtrace.buildVersion,
-             "application.session": MetricsInfo.session];
+             "application.session": ApplicationInfo.session];
     }
 }
 

--- a/Sources/Features/Metrics/BacktraceMetrics.swift
+++ b/Sources/Features/Metrics/BacktraceMetrics.swift
@@ -22,7 +22,6 @@ import Foundation
     }
 
     @objc public func enable(settings: BacktraceMetricsSettings) {
-        MetricsInfo.enableMetrics()
         backtraceMetricsContainer = BacktraceMetricsContainer(settings: settings)
         guard let containerUnwrapped = backtraceMetricsContainer else {
             BacktraceLogger.error("Could not initialize Backtrace metrics sender")

--- a/Tests/AttributesTests.swift
+++ b/Tests/AttributesTests.swift
@@ -70,18 +70,10 @@ final class AttributesTests: QuickSpec {
         }
 
         describe("Metrics Info") {
-            it("will always set application.version and application.session even if metrics system is disabled") {
-                let attributes = MetricsInfo()
-                expect { attributes.immutable["application.version"]}.notTo(beNil())
-                expect { attributes.immutable["application.session"]}.notTo(beNil())
-            }
-
             it("will always set application.version and application.session ") {
-                let attributes = MetricsInfo()
-                MetricsInfo.enableMetrics()
+                let attributes = ApplicationInfo()
                 expect { attributes.immutable["application.version"]}.toNot(beNil())
                 expect { attributes.immutable["application.session"]}.toNot(beNil())
-                MetricsInfo.disableMetrics()
             }
         }
 
@@ -109,14 +101,6 @@ final class AttributesTests: QuickSpec {
                 let attributes = AttributesProvider()
                 expect { attributes.allAttributes["application.version"]}.notTo(beNil())
                 expect { attributes.allAttributes["application.session"]}.notTo(beNil())
-            }
-
-            it("will always set application.version and application.session ") {
-                MetricsInfo.enableMetrics()
-                let attributes = AttributesProvider()
-                expect { attributes.allAttributes["application.version"]}.notTo(beNil())
-                expect { attributes.allAttributes["application.session"]}.notTo(beNil())
-                MetricsInfo.disableMetrics()
             }
         }
 

--- a/Tests/BacktraceMetricsTest.swift
+++ b/Tests/BacktraceMetricsTest.swift
@@ -13,16 +13,12 @@ final class BacktraceMetricsTests: QuickSpec {
             let credentials =
                 BacktraceCredentials(endpoint: URL(string: "https://yourteam.backtrace.io")!, token: "")
             let backtraceApi = BacktraceApi(credentials: credentials, session: urlSession, reportsPerMin: 30)
-            let metrics = BacktraceMetrics(api: backtraceApi)
 
             let summedEventName = "view-changed"
             let uniqueEventName = "guid"
 
-            afterEach {
-                MetricsInfo.disableMetrics()
-            }
-
             it("clears the summed event after enabling and sending") {
+                let metrics = BacktraceMetrics(api: backtraceApi)
                 metrics.enable(settings: BacktraceMetricsSettings())
 
                 // Allow default events to be "sent" out
@@ -30,6 +26,7 @@ final class BacktraceMetricsTests: QuickSpec {
             }
 
             it("can add and store summed event") {
+                let metrics = BacktraceMetrics(api: backtraceApi)
                 metrics.enable(settings: BacktraceMetricsSettings())
 
                 // Allow default events to be "sent" out
@@ -40,6 +37,7 @@ final class BacktraceMetricsTests: QuickSpec {
             }
 
             it("can add and store unique event") {
+                let metrics = BacktraceMetrics(api: backtraceApi)
                 metrics.enable(settings: BacktraceMetricsSettings())
 
                 // Allow default events to be "sent" out

--- a/Tests/BacktraceReporterTests.swift
+++ b/Tests/BacktraceReporterTests.swift
@@ -198,10 +198,7 @@ final class BacktraceReporterTests: QuickSpec {
                     expect { result.report?.attributes["application.version"] }.notTo(beNil())
                 }
 
-                it("report should have metrics attributes if metrics is enabled") {
-                    let metrics = BacktraceMetrics(api: backtraceApi)
-                    metrics.enable(settings: BacktraceMetricsSettings())
-
+                it("report should have metrics attributes") {
                     let delegate = BacktraceClientDelegateMock()
                     let backtraceReport = try reporter.generate()
                     urlSession.response = MockOkResponse()
@@ -218,8 +215,6 @@ final class BacktraceReporterTests: QuickSpec {
                     expect { result.backtraceStatus }.to(equal(.ok))
                     expect { result.report?.attributes["application.session"] }.toNot(beNil())
                     expect { result.report?.attributes["application.version"] }.toNot(beNil())
-
-                    MetricsInfo.disableMetrics()
                 }
 #if os(iOS)
                 it("report should have breadcrumbs attributes if breadcrumbs is enabled") {


### PR DESCRIPTION
# Why
This pull request always adds metrics that we thought are "metrics specific". We always want to include the session id, application version application build in the crash reports. 