### PR TITLE
Initialize with Backtrace-PlCrashReporter configuration

### DIFF
--- a/Sources/Public/BacktraceCrashReporter.swift
+++ b/Sources/Public/BacktraceCrashReporter.swift
@@ -11,7 +11,7 @@ import Darwin
 
     /// Creates an instance of a crash reporter.
     /// - Parameter config: A `PLCrashReporterConfig` configuration to use.
-    @objc public convenience init(config: PLCrashReporterConfig = PLCrashReporterConfig.defaultConfiguration()) {
+    @objc public convenience init(config: PLCrashReporterConfig = PLCrashReporterConfig(signalHandlerType: .BSD, symbolicationStrategy: .all)) {
         self.init(reporter: PLCrashReporter(configuration: config))
     }
 


### PR DESCRIPTION
# Why

Once we updated PlCrashReporter and stopped using our version, we didn't change the PlCrashReporter default configuration that we had in our fork. Based on this pull request: https://github.com/backtrace-labs/plcrashreporter/pull/9/files we always applied a different plcrashreporter config.

This pull request recovers the old plcrashreporter configuration