### PR TITLE
Update Transformer class to NSSecureUnarchiveFromData

### DIFF
--- a/Sources/Features/Resources/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Sources/Features/Resources/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="24B83" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Crash" representedClassName="Crash" syncable="YES">
-        <attribute name="attachmentPaths" optional="YES" attributeType="Transformable" valueTransformerName=""/>
+        <attribute name="attachmentPaths" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
         <attribute name="dateAdded" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="hashProperty" optional="YES" attributeType="String"/>
         <attribute name="reportData" optional="YES" attributeType="Binary"/>


### PR DESCRIPTION
- Updates Transformer class to NSSecureUnarchiveFromData for attachmentPaths (NSKeyedUnarchiver deprecated)

ref: BT-5433