### PR TITLE
doc-comment parameter name mismatch

### DIFF
--- a/Sources/Public/BacktraceClientCustomizing.swift
+++ b/Sources/Public/BacktraceClientCustomizing.swift
@@ -169,7 +169,7 @@ enum BacktraceUrlParsingError: Error {
     ///
     /// - Parameters:
     ///   - message: The message to add.
-    ///   - level: The breadcrumb severity level to add
+    ///   - type: The Breadcrumb type to add
     @objc func addBreadcrumb(_ message: String,
                              type: BacktraceBreadcrumbType) -> Bool
 


### PR DESCRIPTION
- Fixes doc-comment parameter name mismatch ("level" → "type")

ref: BT-5501