### PR TITLE
OSInfo UIKit & UIDevice

### DIFF
--- a/Sources/Features/Attributes/System.swift
+++ b/Sources/Features/Attributes/System.swift
@@ -1,6 +1,9 @@
 import Foundation
 import MachO
 import Darwin
+#if canImport(UIKit)
+import UIKit
+#endif
 
 struct Statistics {
 
@@ -336,7 +339,7 @@ struct OSInfo {
         return "tvOS"
         #elseif os(watchOS)
         return "watchOS"
-        #elseif os(iOS) && !targetEnvironment(macCatalyst)
+        #elseif os(iOS) && canImport(UIKit) && !targetEnvironment(macCatalyst)
         return UIDevice.current.systemName
         #elseif os(iOS) && targetEnvironment(macCatalyst)
         return "Catalyst"
@@ -346,7 +349,7 @@ struct OSInfo {
     }
 
     static var version: String {
-        #if os(iOS) && !targetEnvironment(macCatalyst)
+        #if os(iOS) && canImport(UIKit) && !targetEnvironment(macCatalyst)
         return UIDevice.current.systemVersion
         #elseif os(watchOS)
         let version = ProcessInfo.processInfo.operatingSystemVersion


### PR DESCRIPTION
Adds OSInfo conditional import UIKit & guards UIDevice to unblock non-UIKit builds.

## Why 

SwiftPM / Xcode 16 now compiles each Swift target for the host platform first (macOS in our SauceWebDriverAgent).
OSInfo always imported and used UIDevice, which is now unavailable outside UIKit.

ref: BT-5891