### PR TITLE
bump `exact` PLCR dep to 1.12.0 per @melekr recommendation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/microsoft/plcrashreporter.git",
         "state": {
           "branch": null,
-          "revision": "6752f71de206f6a53fa6a758c3660fd9a7fe7527",
-          "version": "1.11.2"
+          "revision": "8c61e5e38e9f737dd68512ed1ea5ab081244ad65",
+          "version": "1.12.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "Backtrace", targets: ["Backtrace"])
     ],
     dependencies: [
-        .package(url: "https://github.com/microsoft/plcrashreporter.git", .exact("1.11.2")),
+        .package(url: "https://github.com/microsoft/plcrashreporter.git", .exact("1.12.0")),
         .package(url: "https://github.com/Quick/Nimble.git", from: "10.0.0"),
         .package(url: "https://github.com/Quick/Quick.git", from: "5.0.1")
     ],


### PR DESCRIPTION
We noticed this yesterday when on a new macOS project from Xcode 16.4 the initial package resolution failed with:

```
Failed to resolve dependencies Dependencies could not be resolved because root depends on 'backtrace-cocoa 2.0.9..<3.0.0 and root depends on 'plcrashreporter' 1.12.0..<2.0.0. 'backtrace-cocoa' >= 2.0.9 practically depends on 'plcrashreporter' 1.11.1 because 'backtrace-cocoa' 2.0.9 depends on 'plcrashreporter' 1.11.1
```

Showing an attempt to pin to PLCR 1.12 or higher.  Which though it doesn't match the `exact` pin here to 1.11.2 presumably from stale package resolution caching, would have still failed when trying to meet >= 1.12.  Dropping the requirement to 1.11 then resolved the packages.

ATTN @melekr who graciously encouraged me to open this, my first backtrace MR 🙇 